### PR TITLE
Fix: Remove web_accessible_resources from manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,11 +18,5 @@
     "16": "images/icon16.svg",
     "48": "images/icon48.svg",
     "128": "images/icon128.svg"
-  },
-  "web_accessible_resources": [
-    {
-      "resources": [ "images/*.svg" ],
-      "matches": [ "<all_urls>" ]
-    }
-  ]
+  }
 }


### PR DESCRIPTION
The extension icons were not loading because of an issue in the manifest file. The `web_accessible_resources` key is not required for the action and extension icons, and its presence was likely causing a manifest parsing error that prevented the extension from loading correctly.

By removing this unnecessary key, the manifest is simplified and the extension can load without errors, allowing the icons to be displayed as intended.